### PR TITLE
cambio cliente -> si no tiene turnos reservados

### DIFF
--- a/client/src/app/user-dashboard/reservas/page.jsx
+++ b/client/src/app/user-dashboard/reservas/page.jsx
@@ -41,6 +41,10 @@ export default function Reservas() {
 
   return (
     <div className="">
+      <h1 className=" text-center font-rocksalt text-artistfont text-[28px]">
+        {" "}
+        Mis turnos
+      </h1>
       {appointment && appointment.length > 0 ? (
         [...user.appointments]
           .sort((a, b) => new Date(a.dateAndTime) - new Date(b.dateAndTime))
@@ -65,16 +69,17 @@ export default function Reservas() {
           )
       ) : (
         <div className="flex flex-col items-center">
-          <h5 className="text-artistfont">
-            {" "}
+          {" "}
+          <p className="text-artistfont mt-8">
             No tienes ninguna reserva aún. ¡Descubre increíbles artistas y sus
             últimas obras!
-          </h5>
-          <Link href="/explore">
-            <button className="bg-primary text-white py-2 px-4 rounded mt-4">
-              Explorar Artistas
-            </button>
-          </Link>
+          </p>{" "}
+          <br />{" "}
+          <p className="text-artistfont mr-5 ml-5 mb-5">
+            Si te gusta el trabajo de alguno de ellos, puedes acceder a su
+            perfil y reservar un turno para hacer realidad ese tatuaje que tanto
+            deseas.{" "}
+          </p>{" "}
           <div className="scroll-fade flex justify-center items-center">
             <div>
               {artist?.map((filter) => (


### PR DESCRIPTION
Cambié el texto de lo que se muestra si el cliente no tiene turnos reservados. Queda más en sintonía con lo que le aparece al artista si no tiene turno reservados. Saqué el botón que te mandaba al explorar, porque ya abajo aparecen las publicaciones de todos los artistas y quedaba redundante.
Adjunto fotos acá de cómo quedó

<img width="1440" alt="Captura de pantalla 2023-12-13 a la(s) 12 18 43" src="https://github.com/santicasalis/ConnectInk/assets/111137199/35a4f2f4-f98f-4e87-9c86-7f736cf654cd">
<img width="1440" alt="Captura de pantalla 2023-12-13 a la(s) 12 21 29" src="https://github.com/santicasalis/ConnectInk/assets/111137199/f6dc0206-4c2d-4e59-874e-c7ae156c8ff8">
